### PR TITLE
serializer update

### DIFF
--- a/rareapi/serializers.py
+++ b/rareapi/serializers.py
@@ -40,12 +40,17 @@ class PostSerializer(serializers.ModelSerializer):
 
 class CommentSerializer(serializers.ModelSerializer):
     """JSON serializer for comments"""
-    author_id = serializers.IntegerField()
-    post_id = serializers.IntegerField()
+    author = serializers.SerializerMethodField()
+
+    def get_author(self, obj):
+        return {
+            "first_name": obj.author.first_name,
+            "last_name": obj.author.last_name
+        }
 
     class Meta:
         """Meta class for CommentSerializer"""
         model = Comment
-        fields = ('id', 'author_id', 'post_id', 'content', 'created_on')
+        fields = ('id', 'author', 'post_id', 'content', 'created_on')
         depth = 1  # Include related user and post data in the serialized output
 


### PR DESCRIPTION
This pull request updates the `CommentSerializer` in `rareapi/serializers.py` to improve the representation of the `author` field by including detailed information about the author's name instead of just their ID.

Changes to `CommentSerializer`:

* Replaced the `author_id` field with a custom `author` field that uses `SerializerMethodField` to provide the author's `first_name` and `last_name`.
* Updated the `fields` list in the `Meta` class to reflect the new `author` field instead of `author_id`.